### PR TITLE
Update HMACValidator.cs

### DIFF
--- a/Adyen/Util/HMACValidator.cs
+++ b/Adyen/Util/HMACValidator.cs
@@ -95,7 +95,7 @@ namespace Adyen.Util
                 Convert.ToString(amount.Value),
                 amount.Currency,
                 notificationRequestItem.EventCode,
-                notificationRequestItem.Success.ToString()
+                notificationRequestItem.Success.ToString().toLower()
             };
             return String.Join(":", signedDataList);
         }


### PR DESCRIPTION
In the example on the website the boolean is shown with a lowercase t. 
I presume (maybe mistakenly) that the encyption done on the adyenside is done with a lower case t(rue) or f(alse)
doing this in dotnet will result in a string with an uppercase T or F.  (that why is propose a ToLower()
rendering a different hash and will give a false negative.